### PR TITLE
feat(dependencies): bump dependency versions

### DIFF
--- a/lib/directive.js
+++ b/lib/directive.js
@@ -74,6 +74,13 @@ MongoDirective.parseExpression = function(expression){
 };
 
 /**
+ * Open the connection and execute the callback.
+ * @param uri {String} Database URI
+ * @param callback {Function}
+ */
+MongoDirective.open = MongoClient.connect;
+
+/**
  * Close the connection and execute the callback (passing the error).
  * @param err {*} Error
  * @param db {MongoClient} Database
@@ -101,7 +108,7 @@ MongoDirective.prototype.handle = function(context, _tree, _metadata, callback){
     return callback(e);
   }
 
-  MongoClient.connect(this.uri, function(err, db){
+  MongoDirective.open(this.uri, function(err, db){
 
     if (err) return MongoDirective.closeAndFail(err, db, callback);
 
@@ -113,7 +120,7 @@ MongoDirective.prototype.handle = function(context, _tree, _metadata, callback){
                           new MongoDocumentNotFoundError(parsed.collection, parsed.query), db, callback);
 
       db.close();
-      
+
       callback(null, context.resolve(doc));
     });
   });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trbl-evergreen-mongo",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "MongoDB branch source directive",
   "main": "index.js",
   "directories": {
@@ -27,14 +27,15 @@
   },
   "homepage": "https://github.com/the-terribles/evergreen-mongo#readme",
   "devDependencies": {
-    "chai": "^3.5.0",
-    "istanbul": "^0.4.3",
-    "mocha": "^2.4.5",
-    "sinon": "^1.17.3",
+    "chai": "^4.1.2",
+    "istanbul": "^0.4.5",
+    "mocha": "^5.2.0",
+    "mongo-mock": "^3.1.0",
+    "sinon": "^6.1.3",
     "trbl-evergreen": "0.0.5"
   },
   "dependencies": {
-    "mongodb": "^2.1.17",
-    "safe-eval": "^0.2.0"
+    "mongodb": "^3.1.1",
+    "safe-eval": "^0.3.0"
   }
 }

--- a/test/directive_spec.js
+++ b/test/directive_spec.js
@@ -3,10 +3,12 @@
 var chai = require('chai'),
     expect = chai.expect,
     util = require('util'),
+    sinon = require('sinon'),
     errors = require('../lib/errors'),
     DirectiveContext = require('trbl-evergreen/lib/directive-context.js'),
     TestUtils = require('trbl-evergreen/test/utils.js'),
-    MongoClient = require('mongodb').MongoClient,
+    mongodb = require('mongo-mock'),
+    MongoClient = mongodb.MongoClient,
     MongoError = require('mongodb').MongoError,
     MongoDirective = require('../lib/directive');
 
@@ -26,6 +28,15 @@ describe('Mongo Branch Source Directive', function() {
           next();
         });
       });
+    });
+  });
+
+  before(function(){
+    sinon.replace(MongoDirective, 'open', function(uri, callback){
+      if (uri === 'mongodb://localhost:27018/test') {
+        return callback(new MongoError('failed to connect to server [localhost:27018]'));
+      }
+      return MongoClient.connect(uri, callback);
     });
   });
 


### PR DESCRIPTION
## Description

GitHub was complaining about security vulnerabilities in the project dependencies, so the PR upgrades all of them to their latest versions.
Additionally, the spec has been refactored so it doesn't need a mongo instance up and running.
Hope you don't mind @rclayton-the-terrible 